### PR TITLE
Ll/k8 demo fixes

### DIFF
--- a/examples/eidolon_examples/k8_monitor/k8_logic_unit.py
+++ b/examples/eidolon_examples/k8_monitor/k8_logic_unit.py
@@ -4,14 +4,14 @@ from functools import cache
 from typing import Literal
 
 import kubernetes
-from kubernetes.client import CoreV1Api, ApiException, OpenApiException
+from kubernetes.client import CoreV1Api, ApiException, OpenApiException, AppsV1Api
 from pydantic import BaseModel
 from pydantic_core import to_jsonable_python
 
-from eidolon_ai_sdk.cpu.logic_unit import LogicUnit, llm_function
 from eidolon_ai_client.events import StringOutputEvent, OutputEvent
-from eidolon_ai_sdk.system.reference_model import Specable
 from eidolon_ai_client.util.logger import logger
+from eidolon_ai_sdk.cpu.logic_unit import LogicUnit, llm_function
+from eidolon_ai_sdk.system.reference_model import Specable
 
 
 class K8LogicUnitSpec(BaseModel):
@@ -21,62 +21,80 @@ class K8LogicUnitSpec(BaseModel):
 
 
 class K8LogicUnit(Specable[K8LogicUnitSpec], LogicUnit):
-    _client: CoreV1Api = None
+    loaded = False
 
-    def client(self):
-        if not self._client:
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if not K8LogicUnit.loaded:
             kubernetes.config.load_kube_config()
-            self._client = CoreV1Api()
-        return self._client
+            K8LogicUnit.loaded = True
+        for api in [CoreV1Api, AppsV1Api]:
+            description = (
+                f"This tool gives access to query and modify a kubernetes cluster.\n"
+                f"It is a wrapper around kubernetes.client.api.\n"
+                f"It will call functions on the {api.__name__} object and return the results.\n\n"
+                'Example:\nfunction_name="list_namespaced_pod", kwargs='
+                '\{"namespace": "default", "limit": 20\}\n\n'
+                f"When called, this tool will execute the following logic: getattr({api.__name__}(), function_name)(**kwargs)"
+            )
+            setattr(
+                self,
+                api.__name__,
+                llm_function(description=description)(K8LogicUnit._tool_builder(api)),
+            )
 
-    @llm_function()
-    async def core_v1_api(self, function_name: str, kwargs: dict = None):
-        """
-        This tool gives access to query and modify a kubernetes cluster.
-        It is a wrapper around kubernetes.client.CoreV1Api.
-        It will call functions on the CoreV1Api object and return the results.
+    @staticmethod
+    def _tool_builder(api):
+        async def _tool_fn(self, function_name: str, kwargs: dict = None):
+            """
+            This tool gives access to query and modify a kubernetes cluster.
+            It is a wrapper around kubernetes.client.CoreV1Api.
+            It will call functions on the CoreV1Api object and return the results.
 
-        Example:
-            function_name="list_namespaced_pod", kwargs={"namespace": "default", "limit": 20}
+            Example:
+                function_name="list_namespaced_pod", kwargs={"namespace": "default", "limit": 20}
 
-        When called, this tool will execute the following logic: getattr(CoreV1Api(), function_name)(**kwargs)
-        """
-        fn = function_name
-        kwargs = kwargs or {}
+            When called, this tool will execute the following logic: getattr(CoreV1Api(), function_name)(**kwargs)
+            """
+            fn = function_name
+            kwargs = kwargs or {}
 
-        self.check_args(fn, kwargs)
+            self.check_args(api, fn, kwargs)
 
-        try:
-            resp = getattr(self.client(), fn)(**kwargs)
-        except OpenApiException as e:
-            if not isinstance(e, ApiException):
-                # give agent some more information on the endpoint if they are calling it improperly
-                yield StringOutputEvent(content=f"{fn} docs:\n" + getattr(self.client(), fn).__doc__)
-            raise e
-        resp = to_jsonable_python(resp.to_dict())
-        if self.spec.condense_output:
-            resp = _condense(resp)
-        limited = False
-        if self.spec.soft_character_limit and 0 < self.spec.soft_character_limit < len(str(resp)):
-            limited = _limit_obj(resp, self.spec.soft_character_limit)
+            api_instance = api()
+            try:
+                resp = getattr(api_instance, fn)(**kwargs)
+            except OpenApiException as e:
+                if not isinstance(e, ApiException):
+                    # give agent some more information on the endpoint if they are calling it improperly
+                    yield StringOutputEvent(content=f"{fn} docs:\n" + getattr(api_instance, fn).__doc__)
+                raise e
+            resp = to_jsonable_python(resp.to_dict())
+            if self.spec.condense_output:
+                resp = _condense(resp)
+            limited = False
+            if self.spec.soft_character_limit and 0 < self.spec.soft_character_limit < len(str(resp)):
+                limited = _limit_obj(resp, self.spec.soft_character_limit)
 
-        content = dict(request_time_iso=datetime.now().isoformat(), response=resp)
-        if limited:
-            content[
-                "extra"
-            ] = "Portions of the response were too large and were replaced with '...'. Request specific resources for more details"
-        yield OutputEvent.get(content=content)
+            content = dict(request_time_iso=datetime.now().isoformat(), response=resp)
+            if limited:
+                content[
+                    "extra"
+                ] = "Portions of the response were too large and were replaced with '...'. Request specific resources for more details"
+            yield OutputEvent.get(content=content)
 
-    def check_args(self, fn, kwargs):
+        return _tool_fn
+
+    def check_args(self, api, fn, kwargs):
         if fn.startswith("_"):
             raise ValueError("Private functions are not allowed")
         if fn.startswith("_"):
             raise ValueError("Private functions are not allowed")
-        if not hasattr(self.client(), fn) or not callable(getattr(self.client(), fn)):
+        if not hasattr(api, fn) or not callable(getattr(api, fn)):
             raise ValueError(f"Function {fn} is not recognized")
-        is_safe = fn in K8LogicUnit.safe_operations()
-        is_dangerous = fn in K8LogicUnit.dangerous_operations()
-        is_safe_with_dry_run = fn in K8LogicUnit.safe_with_dry_run()
+        is_safe = fn in K8LogicUnit.safe_operations(api)
+        is_dangerous = fn in K8LogicUnit.dangerous_operations(api)
+        is_safe_with_dry_run = fn in K8LogicUnit.safe_with_dry_run(api)
         if not (is_safe or is_dangerous or is_safe_with_dry_run):
             if self.spec.safety_level == "unrestricted":
                 logger.warning(f"Function {fn} is not recognized")
@@ -84,7 +102,7 @@ class K8LogicUnit(Specable[K8LogicUnitSpec], LogicUnit):
                 raise ValueError(f"Function {fn} is not recognized")
 
         if self.spec.safety_level == "read_only":
-            if fn not in K8LogicUnit.safe_operations():
+            if fn not in K8LogicUnit.safe_operations(api):
                 raise ValueError(f"Cannot perform {fn} with current safety level {self.spec.safety_level}")
         elif self.spec.safety_level == "no_mutations":
             if is_dangerous:
@@ -94,30 +112,33 @@ class K8LogicUnit(Specable[K8LogicUnitSpec], LogicUnit):
                     f"Must set dry_run='All' to perform {fn} with current safety level {self.spec.safety_level}"
                 )
 
-    _operations = [
-        (f, getattr(CoreV1Api, f)) for f in dir(CoreV1Api) if not f.startswith("_") and callable(getattr(CoreV1Api, f))
-    ]
+    @staticmethod
+    @cache
+    def _operations(api):
+        return [(f, getattr(api, f)) for f in dir(api) if not f.startswith("_") and callable(getattr(api, f))]
 
     @staticmethod
     @cache
-    def safe_operations():
+    def safe_operations(api=CoreV1Api):
         return {
-            o for o, f in K8LogicUnit._operations if o.startswith("list") or o.startswith("read") or o.startswith("get")
+            o
+            for o, f in K8LogicUnit._operations(api)
+            if o.startswith("list") or o.startswith("read") or o.startswith("get")
         }
 
     @staticmethod
     @cache
-    def safe_with_dry_run():
+    def safe_with_dry_run(api=CoreV1Api):
         return {
             o
-            for o, f in K8LogicUnit._operations
+            for o, f in K8LogicUnit._operations(api)
             if o.startswith("create") or o.startswith("replace") or o.startswith("patch") or o.startswith("delete")
         }
 
     @staticmethod
     @cache
-    def dangerous_operations():
-        return {o for o, f in K8LogicUnit._operations if o.startswith("connect")}
+    def dangerous_operations(api=CoreV1Api):
+        return {o for o, f in K8LogicUnit._operations(api) if o.startswith("connect")}
 
 
 def _condense(obj):

--- a/examples/eidolon_examples/k8_monitor/k8_logic_unit.py
+++ b/examples/eidolon_examples/k8_monitor/k8_logic_unit.py
@@ -4,7 +4,8 @@ from functools import cache
 from typing import Literal
 
 import kubernetes
-from kubernetes.client import CoreV1Api, ApiException, OpenApiException, AppsV1Api
+from kubernetes.client import CoreV1Api, ApiException, OpenApiException, AppsV1Api, RbacAuthorizationV1Api, \
+    StorageV1Api, NetworkingV1Api
 from pydantic import BaseModel
 from pydantic_core import to_jsonable_python
 
@@ -28,7 +29,7 @@ class K8LogicUnit(Specable[K8LogicUnitSpec], LogicUnit):
         if not K8LogicUnit.loaded:
             kubernetes.config.load_kube_config()
             K8LogicUnit.loaded = True
-        for api in [CoreV1Api, AppsV1Api]:
+        for api in [CoreV1Api, AppsV1Api, NetworkingV1Api, StorageV1Api, RbacAuthorizationV1Api]:
             description = (
                 f"This tool gives access to query and modify a kubernetes cluster.\n"
                 f"It is a wrapper around kubernetes.client.api.\n"

--- a/examples/eidolon_examples/k8_monitor/k8_logic_unit.py
+++ b/examples/eidolon_examples/k8_monitor/k8_logic_unit.py
@@ -41,7 +41,7 @@ class K8LogicUnit(Specable[K8LogicUnitSpec], LogicUnit):
             setattr(
                 self,
                 api.__name__,
-                llm_function(description=description)(K8LogicUnit._tool_builder(api)),
+                llm_function(name=api.__name__, description=description)(K8LogicUnit._tool_builder(api)),
             )
 
     @staticmethod

--- a/examples/eidolon_examples/k8_monitor/resources/K8Manager.yaml
+++ b/examples/eidolon_examples/k8_monitor/resources/K8Manager.yaml
@@ -8,21 +8,21 @@ spec:
     You are a DevOps manager who cares deeply about user success.
     You have a team of kubernetes workers, or dev ops engineers that you can delegate tasks to. 
     Each conversation is with a different worker, and you can have as many workers as you need to answer user requests.
-
+    
     Users will come to you with questions about the cluster or requests to perform.
-    
     Users are very busy and you want to help them as much as possible.
-    You want make a plan for how to help the user using your workers.
-    You ask K8Workers to perform actions on behalf of the user when possible.
-    Have workers do your research before asking users follow up questions.
+    
+    Think carefully of what information the user will need.
+    Break the question into small portions that you distribute to multiple workers so each worker solves the smallest problem possible.
+    Assign each task, and the information you need back, to a new workers.
+    You do not bother your workers if you already have the information you need to answer a question.
+    
     Help your workers when they have errors whenever possible so that the user does not need to resolve the error.
-    
     If you need additional information to perform an action, you may ask the user clarifying questions.
-    
     ALWAYS Think carefully and be concise.
   actions:
     - name: converse
       user_prompt: |-
         Current Time ISO: {{ datetime_iso }}
-        {{ prompt }}
+        Request: {{ body }}
   agent_refs: [ K8Worker ]

--- a/examples/eidolon_examples/k8_monitor/resources/K8Manager.yaml
+++ b/examples/eidolon_examples/k8_monitor/resources/K8Manager.yaml
@@ -21,8 +21,7 @@ spec:
     If you need additional information to perform an action, you may ask the user clarifying questions.
     ALWAYS Think carefully and be concise.
   actions:
-    - name: converse
-      user_prompt: |-
+    - user_prompt: |-
         Current Time ISO: {{ datetime_iso }}
         Request: {{ body }}
   agent_refs: [ K8Worker ]

--- a/examples/eidolon_examples/k8_monitor/resources/K8Worker.yaml
+++ b/examples/eidolon_examples/k8_monitor/resources/K8Worker.yaml
@@ -6,8 +6,9 @@ spec:
   system_prompt: |-
     You are a DevOps engineer with direct control of a kubernetes cluster through the K8_core_v1_api tool.
     Your manager (user) will come to you with questions about the cluster or requests to perform. 
-    Your manager is very busy and you want to help them as much as possible.
     Perform actions for your manager when possible.
+    If you have issues, report them to your manager for help.
+    
     
     If you need additional information to perform an action, you may ask your manager clarifying questions.
     ALWAYS Think carefully and be concise.

--- a/examples/eidolon_examples/k8_monitor/resources/K8Worker.yaml
+++ b/examples/eidolon_examples/k8_monitor/resources/K8Worker.yaml
@@ -24,5 +24,4 @@ spec:
         request: {{ request }}
   cpu:
     logic_units:
-     - implementation: eidolon_examples.k8_monitor.k8_logic_unit.K8LogicUnit
-       safety_level: unrestricted
+     - eidolon_examples.k8_monitor.k8_logic_unit.K8LogicUnit

--- a/examples/eidolon_examples/k8_monitor/resources/K8Worker.yaml
+++ b/examples/eidolon_examples/k8_monitor/resources/K8Worker.yaml
@@ -3,25 +3,34 @@ kind: Agent
 metadata:
   name: K8Worker
 spec:
-  description: |-
-    A low level DevOps engineer who specializes in making queries against and mutating a kubernetes cluster.
-    Be specific about what information you need. This worker only has access to it's own conversation history.
   system_prompt: |-
     You are a DevOps engineer with direct control of a kubernetes cluster through the K8_core_v1_api tool.
-    
     Your manager (user) will come to you with questions about the cluster or requests to perform. 
-    
     Your manager is very busy and you want to help them as much as possible.
     Perform actions for your manager when possible.
     
     If you need additional information to perform an action, you may ask your manager clarifying questions.
-    
     ALWAYS Think carefully and be concise.
   actions:
-    - name: converse
+    - name: start_conversation
+      allowed_states: ["initialized"]
+      description: |-
+        Start a conversation with a new DevOps engineer who specializes in making queries against and mutating a kubernetes cluster.
+        Be specific about what action you want performed and what information you need as a response..
       user_prompt: |-
         Current Time ISO: {{ datetime_iso }}
-        request: {{ request }}
+        request: {{ body }}
+    - name: continue_conversation
+      allowed_states: ["idle", "http_error"]
+      description: "Continue an existing conversation with a the specified DevOps engineer."
+      user_prompt: |-
+        Current Time ISO: {{ datetime_iso }}
+        request: {{ body }}
+        
+        Be concise
   cpu:
+    llm_unit:
+      model: gpt-3.5-turbo
     logic_units:
-     - eidolon_examples.k8_monitor.k8_logic_unit.K8LogicUnit
+     - implementation: eidolon_examples.k8_monitor.k8_logic_unit.K8LogicUnit
+#       safety_level: unrestricted

--- a/sdk/eidolon_ai_sdk/agent/simple_agent.py
+++ b/sdk/eidolon_ai_sdk/agent/simple_agent.py
@@ -42,6 +42,9 @@ class ActionDefinition(BaseModel):
         properties: Dict[str, Any] = {}
         required = []
         user_vars = meta.find_undeclared_variables(Environment().parse(self.user_prompt))
+        # pop out any reserved keywords we will inject
+        if "datetime_iso" in user_vars:
+            user_vars.remove("datetime_iso")
         if self.input_schema is not None:
             properties["body"] = dict(type="object", properties=self.input_schema)
             required.append("body")
@@ -49,7 +52,7 @@ class ActionDefinition(BaseModel):
             properties["body"] = dict(type="string", default=Body(..., media_type="text/plain"))
             required.append("body")
         elif user_vars:
-            props = {v: dict(type="string") for v in user_vars if v != "datetime_iso" and v != "body"}
+            props = {v: dict(type="string") for v in user_vars}
             properties["body"] = dict(type="object", properties=props)
             required.append("body")
 

--- a/sdk/eidolon_ai_sdk/cpu/agents_logic_unit.py
+++ b/sdk/eidolon_ai_sdk/cpu/agents_logic_unit.py
@@ -115,10 +115,13 @@ class AgentsLogicUnit(Specable[AgentsLogicUnitSpec], LogicUnit):
     @staticmethod
     def _body_model(endpoint_schema, name):
         body = endpoint_schema.get("requestBody")
-        if body and "application/json" not in body["content"]:
-            raise ValueError(f"Agent action at {name} does not support application/json")
-        json_schema = body["content"]["application/json"]["schema"] if body else dict(type="object", properties={})
-        return schema_to_model(dict(type="object", properties=dict(body=json_schema)), "Input")
+        if "application/json" in body["content"]:
+            json_schema = body["content"]["application/json"]["schema"] if body else dict(type="object", properties={})
+            return schema_to_model(dict(type="object", properties=dict(body=json_schema)), "Input")
+        elif "text/plain" in body["content"]:
+            return schema_to_model(dict(type="object", properties=dict(body=dict(type="string"))), "Input")
+        else:
+            raise ValueError(f"Agent action at {name} does not support text/plain or application/json")
 
     @staticmethod
     def _description(endpoint_schema, name):

--- a/sdk/eidolon_ai_sdk/cpu/agents_logic_unit.py
+++ b/sdk/eidolon_ai_sdk/cpu/agents_logic_unit.py
@@ -115,8 +115,11 @@ class AgentsLogicUnit(Specable[AgentsLogicUnitSpec], LogicUnit):
     @staticmethod
     def _body_model(endpoint_schema, name):
         body = endpoint_schema.get("requestBody")
-        if "application/json" in body["content"]:
-            json_schema = body["content"]["application/json"]["schema"] if body else dict(type="object", properties={})
+        if not body:
+            json_schema = dict(type="object", properties={})
+            return schema_to_model(dict(type="object", properties=dict(body=json_schema)), "Input")
+        elif "application/json" in body["content"]:
+            json_schema = body["content"]["application/json"]["schema"]
             return schema_to_model(dict(type="object", properties=dict(body=json_schema)), "Input")
         elif "text/plain" in body["content"]:
             return schema_to_model(dict(type="object", properties=dict(body=dict(type="string"))), "Input")

--- a/sdk/eidolon_ai_sdk/cpu/conversational_agent_cpu.py
+++ b/sdk/eidolon_ai_sdk/cpu/conversational_agent_cpu.py
@@ -149,7 +149,7 @@ class ConversationalAgentCPU(AgentCPU, Specable[ConversationalAgentCPUSpec], Pro
             ToolCallStartEvent(
                 tool_call=tc,
                 context_id=tc.tool_call_id,
-                title=tool_def.eidolon_handler.extra["title"],
+                title=tool_def.eidolon_handler.extra.get("title", tool_def.eidolon_handler.name),
                 sub_title=tool_def.eidolon_handler.extra.get("sub_title", ""),
                 is_agent_call=tool_def.eidolon_handler.extra.get("agent_call", False),
             ),

--- a/sdk/eidolon_ai_sdk/cpu/llm/open_ai_llm_unit.py
+++ b/sdk/eidolon_ai_sdk/cpu/llm/open_ai_llm_unit.py
@@ -208,7 +208,9 @@ class OpenAIGPT(LLMUnit, Specable[OpenAiGPTSpec]):
 
                 content = json.loads(complete_message) if complete_message else {}
                 yield ObjectOutputEvent(content=content)
-        except APIConnectionError | InternalServerError as e:
+        except APIConnectionError as e:
+            raise HTTPException(502, f"OpenAI Error: {e.message}") from e
+        except InternalServerError as e:
             raise HTTPException(502, f"OpenAI Error: {e.message}") from e
         except RateLimitError as e:
             raise HTTPException(429, "OpenAI Rate Limit Exceeded") from e

--- a/sdk/eidolon_ai_sdk/cpu/logic_unit.py
+++ b/sdk/eidolon_ai_sdk/cpu/logic_unit.py
@@ -46,7 +46,7 @@ class LLMToolWrapper:
                 yield SuccessEvent()
         except Exception as e:
             logging.exception("error calling tool " + self.eidolon_handler.name)
-            yield ErrorEvent(reason=e)
+            yield ErrorEvent(reason=str(e))
 
     @classmethod
     async def from_logic_units(

--- a/sdk/tests/cassettes/test_simple_agent/test_refs.yaml
+++ b/sdk/tests/cassettes/test_simple_agent/test_refs.yaml
@@ -7,789 +7,6 @@ interactions:
         bHBmdWwgYXNzaXN0YW50In0sIHsicm9sZSI6ICJ1c2VyIiwgImNvbnRlbnQiOiBbeyJ0eXBlIjog
         InRleHQiLCAidGV4dCI6ICJTdGFydCBhIGNvbnZlcnNhdGlvbiB3aXRoIHN5c3RlbV9wcm9tcHQg
         YW5kIHdoYXQgaXRzIGZhdm9yaXRlIGNvdW50cnkgaXMuIn1dfV0sICJtb2RlbCI6ICJncHQtNC10
-        dXJiby1wcmV2aWV3IiwgInN0cmVhbSI6IHRydWUsICJ0ZW1wZXJhdHVyZSI6IDAuM30=
-      - 0
-      - null
-    headers:
-      accept:
-      - application/json
-      accept-encoding:
-      - gzip, deflate
-      authorization:
-      - XXXXXX
-      connection:
-      - keep-alive
-      content-length:
-      - '278'
-      content-type:
-      - application/json
-      host:
-      - api.openai.com
-      user-agent:
-      - AsyncOpenAI/Python 1.11.1
-      x-stainless-arch:
-      - x64
-      x-stainless-async:
-      - async:asyncio
-      x-stainless-lang:
-      - python
-      x-stainless-os:
-      - MacOS
-      x-stainless-package-version:
-      - 1.11.1
-      x-stainless-runtime:
-      - CPython
-      x-stainless-runtime-version:
-      - 3.11.7
-    method: POST
-    uri: https://api.openai.com/v1/chat/completions
-  response:
-    content: 'data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"Sure"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      I"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"''ll"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      simulate"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      a"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      conversation"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      for"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      you"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":".\n\n"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"---\n\n"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"**"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"User"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":":**"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      Hey"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      what"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"''s"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      your"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      favorite"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      country"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"?\n\n"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"**"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"System"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"_P"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"rompt"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":":**"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      Well"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      as"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      an"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      AI"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      I"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      don"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"''t"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      have"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      personal"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      preferences"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      or"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      feelings"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      but"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      I"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      can"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      tell"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      you"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      about"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      any"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      country"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      you"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"''re"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      interested"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      in"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      Is"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      there"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      a"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      particular"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      place"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      you"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"''d"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      like"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      to"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      learn"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      more"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      about"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"?\n\n"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"**"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"User"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":":**"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      That"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"''s"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      interesting"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      Can"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      you"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      tell"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      me"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      which"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      country"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      is"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      the"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      most"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      popular"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      among"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      users"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      when"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      they"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      ask"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      about"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      travel"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"?\n\n"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"**"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"System"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"_P"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"rompt"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":":**"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      While"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      I"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      don"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"''t"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      have"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      access"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      to"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      real"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"-time"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      data"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      or"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      user"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      queries"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      I"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      can"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      share"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      that"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      popular"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      travel"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      destinations"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      often"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      include"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      countries"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      like"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      France"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      Japan"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      Italy"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      and"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      the"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      United"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      States"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      These"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      countries"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      are"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      known"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      for"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      their"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      rich"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      cultures"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      beautiful"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      landscapes"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      and"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      historical"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      landmarks"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      Would"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      you"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      like"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      to"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      know"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      more"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      about"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      any"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      of"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      these"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      countries"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      or"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      perhaps"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      another"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      one"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"?\n\n"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"---\n\n"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"Let"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      me"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      know"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      if"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      you"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      need"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      more"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      information"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      or"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      have"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      any"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      other"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"
-      questions"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}]}
-
-
-      data: {"id":"chatcmpl-8uBI23mWuebkJHmWUbwXXuviFVT61","object":"chat.completion.chunk","created":1708400458,"model":"gpt-4-0125-preview","system_fingerprint":"fp_f084bcfc79","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
-
-
-      data: [DONE]
-
-
-      '
-    headers:
-      CF-Cache-Status:
-      - DYNAMIC
-      CF-RAY:
-      - 8583bb30cd357203-SEA
-      Cache-Control:
-      - no-cache, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - text/event-stream
-      Date:
-      - Tue, 20 Feb 2024 03:40:58 GMT
-      Server:
-      - cloudflare
-      Set-Cookie:
-      - __cf_bm=5qH8ZZeJjbmoq0YEt17Z05menxe0MGteaCv2awMciYU-1708400458-1.0-ARzd0xoOkFCkG6dx+0rKv8/THbRSAOlSKAoZLCCpTxhX1SQ9ootHMiwYmG7fMI1ZOTXPx2mgsgOL+58Zj3IPm+4=;
-        path=/; expires=Tue, 20-Feb-24 04:10:58 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
-      - _cfuvid=w.RyMgtHldGUJuSy7yVjQMzuGb.zcW4u3NCZVUo_1i4-1708400458806-0.0-604800000;
-        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-      Transfer-Encoding:
-      - chunked
-      access-control-allow-origin:
-      - '*'
-      alt-svc:
-      - h3=":443"; ma=86400
-      openai-model:
-      - gpt-4-0125-preview
-      openai-organization:
-      - august-data
-      openai-processing-ms:
-      - '275'
-      openai-version:
-      - '2020-10-01'
-      strict-transport-security:
-      - max-age=15724800; includeSubDomains
-      x-ratelimit-limit-requests:
-      - '5000'
-      x-ratelimit-limit-tokens:
-      - '600000'
-      x-ratelimit-remaining-requests:
-      - '4999'
-      x-ratelimit-remaining-tokens:
-      - '599956'
-      x-ratelimit-reset-requests:
-      - 12ms
-      x-ratelimit-reset-tokens:
-      - 4ms
-      x-request-id:
-      - req_335c1d84425ca964dfad074831992296
-    http_version: HTTP/1.1
-    status_code: 200
-- request:
-    body: !!python/object/new:_io.BytesIO
-      state: !!python/tuple
-      - !!binary |
-        eyJtZXNzYWdlcyI6IFt7InJvbGUiOiAic3lzdGVtIiwgImNvbnRlbnQiOiAiWW91IGFyZSBhIGhl
-        bHBmdWwgYXNzaXN0YW50In0sIHsicm9sZSI6ICJ1c2VyIiwgImNvbnRlbnQiOiBbeyJ0eXBlIjog
-        InRleHQiLCAidGV4dCI6ICJTdGFydCBhIGNvbnZlcnNhdGlvbiB3aXRoIHN5c3RlbV9wcm9tcHQg
-        YW5kIHdoYXQgaXRzIGZhdm9yaXRlIGNvdW50cnkgaXMuIn1dfV0sICJtb2RlbCI6ICJncHQtNC10
         dXJiby1wcmV2aWV3IiwgInN0cmVhbSI6IHRydWUsICJ0ZW1wZXJhdHVyZSI6IDAuMywgInRvb2xz
         IjogW3sidHlwZSI6ICJmdW5jdGlvbiIsICJmdW5jdGlvbiI6IHsibmFtZSI6ICJBZ2VudHNMb2dp
         Y1VuaXRfY29udm9fc3lzdGVtX3Byb21wdF9jb252ZXJzZSIsICJkZXNjcmlwdGlvbiI6ICIiLCAi
@@ -833,44 +50,45 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"role":"assistant","content":null},"logprobs":null,"finish_reason":null}]}
+      string: 'data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"role":"assistant","content":null},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_KVXM2r2GGwH3BMWM16D7TTQ3","type":"function","function":{"name":"AgentsLogicUnit_convo_system_prompt_converse","arguments":""}}]},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_sihpGuzWApF7ZKllWwowJAe3","type":"function","function":{"name":"AgentsLogicUnit_convo_system_prompt_converse","arguments":""}}]},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"bo"}}]},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"bo"}}]},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"dy\":
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"dy\":
         "}}]},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"What''"}}]},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"What
+        "}}]},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"s
-        yo"}}]},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"is
+        y"}}]},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ur
-        fa"}}]},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"our
+        f"}}]},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"vorite"}}]},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"avorit"}}]},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        cou"}}]},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"e
+        co"}}]},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ntry?"}}]},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"untry"}}]},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"?\"}"}}]},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}]}
+        data: {"id":"chatcmpl-90Og7LlIFnVvGBN5J17ELCXeI5HVE","object":"chat.completion.chunk","created":1709881891,"model":"gpt-4-0125-preview","system_fingerprint":"fp_31c0f205d1","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}]}
 
 
         data: [DONE]
@@ -881,7 +99,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8610dbac3b342766-SEA
+      - 861102fc8fa9309a-SEA
       Cache-Control:
       - no-cache, must-revalidate
       Connection:
@@ -889,14 +107,14 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Fri, 08 Mar 2024 06:44:43 GMT
+      - Fri, 08 Mar 2024 07:11:35 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=FNV1AnoHP4kWdqTQ4v97UwrTpBSu975VZG5UxAii86w-1709880283-1.0.1.1-nW.h4cb3DyCamd1DddhfuSSQNYFn72xk9PpbZ9GFvahMNWIiUj1Eri.0gKzuPQWQ4KZ02qiNUB8TM5qEh9UNfw;
-        path=/; expires=Fri, 08-Mar-24 07:14:43 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=UMs.f6aLXpCypvVS8vGyYSKe3iYPcd6lw76hrpC0dfY-1709881895-1.0.1.1-Czy_akO2Aw7u8Aji.953Rwb7ZGiRcDrQqZzcijJ1TJcwvLP1stkpUQnFnDMlESW7WP.9wh8j6KerZwIargxkqw;
+        path=/; expires=Fri, 08-Mar-24 07:41:35 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=_FbNLC7m6XZ8EHf0VTg5yPrYydbzZZkumT.ghz9WKbY-1709880283765-0.0.1.1-604800000;
+      - _cfuvid=XRv5oZZzgbBjzwwtE1QijP1SgIaMgL1kuPmE9VoWOnA-1709881895653-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -909,7 +127,7 @@ interactions:
       openai-organization:
       - august-data
       openai-processing-ms:
-      - '2654'
+      - '3200'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -927,7 +145,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_046e40895dee812ab744f0005fa60706
+      - req_075eefc00277d60bfc239a488e805e16
     status:
       code: 200
       message: OK
@@ -938,8 +156,8 @@ interactions:
         eyJtZXNzYWdlcyI6IFt7InJvbGUiOiAic3lzdGVtIiwgImNvbnRlbnQiOiAiWW91IGFyZSBhIGhl
         bHBmdWwgYXNzaXN0YW50LCBhbmQgeW91ciBmYXZvcml0ZSBjb3VudHJ5IGlzIEZyYW5jZSJ9LCB7
         InJvbGUiOiAidXNlciIsICJjb250ZW50IjogW3sidHlwZSI6ICJ0ZXh0IiwgInRleHQiOiAiV2hh
-        dCdzIHlvdXIgZmF2b3JpdGUgY291bnRyeT8ifV19XSwgIm1vZGVsIjogImdwdC00LXR1cmJvLXBy
-        ZXZpZXciLCAic3RyZWFtIjogdHJ1ZSwgInRlbXBlcmF0dXJlIjogMC4zfQ==
+        dCBpcyB5b3VyIGZhdm9yaXRlIGNvdW50cnk/In1dfV0sICJtb2RlbCI6ICJncHQtNC10dXJiby1w
+        cmV2aWV3IiwgInN0cmVhbSI6IHRydWUsICJ0ZW1wZXJhdHVyZSI6IDAuM30=
       - 0
       - null
     headers:
@@ -952,7 +170,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '271'
+      - '272'
       content-type:
       - application/json
       host:
@@ -977,200 +195,286 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+      string: 'data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"As"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"My"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        an"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        AI"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        I"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        don"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"''t"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        have"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        personal"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        preferences"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        or"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        feelings"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        so"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        I"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        don"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"''t"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        have"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        a"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
         favorite"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
         country"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        But"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        I"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        can"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        provide"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        information"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        or"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        answer"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        questions"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        about"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        any"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        country"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        including"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
         France"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        which"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        It"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        many"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"''s"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        people"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        known"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        find"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        for"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        fascinating"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        its"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        rich"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        How"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        history"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        can"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        I"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        beautiful"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        assist"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        landscapes"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        and"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        delicious"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        cuisine"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        From"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        iconic"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        E"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"iff"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"el"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        Tower"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        in"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        Paris"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        to"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        stunning"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        lavender"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        fields"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        of"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        Prov"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"ence"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        there"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"''s"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        so"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        much"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        to"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        explore"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        and"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        appreciate"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        Plus"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        art"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        fashion"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        and"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        wine"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        are"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        world"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"-ren"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"owned"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        Is"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        there"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        anything"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        specific"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
         you"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
-        today"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"''d"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        like"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        to"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        know"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        about"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        France"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgBT3IaDzcNXhi1GOPvthppWapa","object":"chat.completion.chunk","created":1709881895,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
 
 
         data: [DONE]
@@ -1181,7 +485,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8610dbc08f07306f-SEA
+      - 861103193af630e9-SEA
       Cache-Control:
       - no-cache, must-revalidate
       Connection:
@@ -1189,14 +493,14 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Fri, 08 Mar 2024 06:44:44 GMT
+      - Fri, 08 Mar 2024 07:11:36 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=CFI3Se0.Ov4Pri7mRg4De2NFS9uMQvj4ut0LCZRmtgk-1709880284-1.0.1.1-XCBq6jQgZ78B17TBX0HjJsK2NyQnAN0eDzzotu8WPONgNqAD.4EOX0qvGzWNtbHHFfsTCGftuWKXQ5v3jctkRg;
-        path=/; expires=Fri, 08-Mar-24 07:14:44 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=6Bihb6lVJCYKL_Ig56ewOUvnwsjSb4qhXRYl3Usp1ak-1709881896-1.0.1.1-TI53o6s88SDqV_veodT0m_hNcT2KCmlK0hza8XUz3kz09i02MyDc6OvX11afYOn6KZdLuypRgryp0I8LOO1EJw;
+        path=/; expires=Fri, 08-Mar-24 07:41:36 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=.ANplCznaf.9ZjKIFbU58VTiqtR3pOYx18XOkIhbUmQ-1709880284641-0.0.1.1-604800000;
+      - _cfuvid=kcDY5xA1ywT6LAv.O4RcuW9POIuiLwOKagvX5jVr1QY-1709881896218-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -1209,7 +513,7 @@ interactions:
       openai-organization:
       - august-data
       openai-processing-ms:
-      - '247'
+      - '192'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -1227,7 +531,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_449fe83d20eb2cdf42bb6e6b1f4ae274
+      - req_2400cfd8a09f9d4245938a6c9b0d63ce
     status:
       code: 200
       message: OK
@@ -1239,26 +543,28 @@ interactions:
         bHBmdWwgYXNzaXN0YW50In0sIHsicm9sZSI6ICJ1c2VyIiwgImNvbnRlbnQiOiBbeyJ0eXBlIjog
         InRleHQiLCAidGV4dCI6ICJTdGFydCBhIGNvbnZlcnNhdGlvbiB3aXRoIHN5c3RlbV9wcm9tcHQg
         YW5kIHdoYXQgaXRzIGZhdm9yaXRlIGNvdW50cnkgaXMuIn1dfSwgeyJyb2xlIjogImFzc2lzdGFu
-        dCIsICJjb250ZW50IjogIiIsICJ0b29sX2NhbGxzIjogW3siaWQiOiAiY2FsbF9LVlhNMnIyR0d3
-        SDNCTVdNMTZEN1RUUTMiLCAidHlwZSI6ICJmdW5jdGlvbiIsICJmdW5jdGlvbiI6IHsibmFtZSI6
+        dCIsICJjb250ZW50IjogIiIsICJ0b29sX2NhbGxzIjogW3siaWQiOiAiY2FsbF9zaWhwR3V6V0Fw
+        RjdaS2xsV3dvd0pBZTMiLCAidHlwZSI6ICJmdW5jdGlvbiIsICJmdW5jdGlvbiI6IHsibmFtZSI6
         ICJBZ2VudHNMb2dpY1VuaXRfY29udm9fc3lzdGVtX3Byb21wdF9jb252ZXJzZSIsICJhcmd1bWVu
-        dHMiOiAieydib2R5JzogXCJXaGF0J3MgeW91ciBmYXZvcml0ZSBjb3VudHJ5P1wifSJ9fV19LCB7
-        InJvbGUiOiAidG9vbCIsICJ0b29sX2NhbGxfaWQiOiAiY2FsbF9LVlhNMnIyR0d3SDNCTVdNMTZE
-        N1RUUTMiLCAiY29udGVudCI6ICJcIkFzIGFuIEFJLCBJIGRvbid0IGhhdmUgcGVyc29uYWwgcHJl
-        ZmVyZW5jZXMgb3IgZmVlbGluZ3MsIHNvIEkgZG9uJ3QgaGF2ZSBhIGZhdm9yaXRlIGNvdW50cnku
-        IEJ1dCBJIGNhbiBwcm92aWRlIGluZm9ybWF0aW9uIG9yIGFuc3dlciBxdWVzdGlvbnMgYWJvdXQg
-        YW55IGNvdW50cnksIGluY2x1ZGluZyBGcmFuY2UsIHdoaWNoIG1hbnkgcGVvcGxlIGZpbmQgZmFz
-        Y2luYXRpbmcuIEhvdyBjYW4gSSBhc3Npc3QgeW91IHRvZGF5P1wiIn1dLCAibW9kZWwiOiAiZ3B0
-        LTQtdHVyYm8tcHJldmlldyIsICJzdHJlYW0iOiB0cnVlLCAidGVtcGVyYXR1cmUiOiAwLjMsICJ0
-        b29scyI6IFt7InR5cGUiOiAiZnVuY3Rpb24iLCAiZnVuY3Rpb24iOiB7Im5hbWUiOiAiQWdlbnRz
-        TG9naWNVbml0X2NvbnZvX3N5c3RlbV9wcm9tcHRfY29udmVyc2UiLCAiZGVzY3JpcHRpb24iOiAi
-        IiwgInBhcmFtZXRlcnMiOiB7InByb3BlcnRpZXMiOiB7ImJvZHkiOiB7ImRlZmF1bHQiOiBudWxs
-        LCAidGl0bGUiOiAiQm9keSIsICJ0eXBlIjogInN0cmluZyJ9fSwgInRpdGxlIjogIklucHV0Iiwg
-        InR5cGUiOiAib2JqZWN0In19fSwgeyJ0eXBlIjogImZ1bmN0aW9uIiwgImZ1bmN0aW9uIjogeyJu
-        YW1lIjogIkFnZW50c0xvZ2ljVW5pdF9jb252b19zeXN0ZW1fcHJvbXB0X2NvbnZlcnNlXzAiLCAi
-        ZGVzY3JpcHRpb24iOiAiIiwgInBhcmFtZXRlcnMiOiB7InByb3BlcnRpZXMiOiB7ImJvZHkiOiB7
-        ImRlZmF1bHQiOiBudWxsLCAidGl0bGUiOiAiQm9keSIsICJ0eXBlIjogInN0cmluZyJ9fSwgInRp
-        dGxlIjogIklucHV0IiwgInR5cGUiOiAib2JqZWN0In19fV19
+        dHMiOiAieydib2R5JzogJ1doYXQgaXMgeW91ciBmYXZvcml0ZSBjb3VudHJ5Pyd9In19XX0sIHsi
+        cm9sZSI6ICJ0b29sIiwgInRvb2xfY2FsbF9pZCI6ICJjYWxsX3NpaHBHdXpXQXBGN1pLbGxXd293
+        SkFlMyIsICJjb250ZW50IjogIlwiTXkgZmF2b3JpdGUgY291bnRyeSBpcyBGcmFuY2UhIEl0J3Mg
+        a25vd24gZm9yIGl0cyByaWNoIGhpc3RvcnksIGJlYXV0aWZ1bCBsYW5kc2NhcGVzLCBhbmQgZGVs
+        aWNpb3VzIGN1aXNpbmUuIEZyb20gdGhlIGljb25pYyBFaWZmZWwgVG93ZXIgaW4gUGFyaXMgdG8g
+        dGhlIHN0dW5uaW5nIGxhdmVuZGVyIGZpZWxkcyBvZiBQcm92ZW5jZSwgdGhlcmUncyBzbyBtdWNo
+        IHRvIGV4cGxvcmUgYW5kIGFwcHJlY2lhdGUuIFBsdXMsIHRoZSBhcnQsIGZhc2hpb24sIGFuZCB3
+        aW5lIGFyZSB3b3JsZC1yZW5vd25lZC4gSXMgdGhlcmUgYW55dGhpbmcgc3BlY2lmaWMgeW91J2Qg
+        bGlrZSB0byBrbm93IGFib3V0IEZyYW5jZT9cIiJ9XSwgIm1vZGVsIjogImdwdC00LXR1cmJvLXBy
+        ZXZpZXciLCAic3RyZWFtIjogdHJ1ZSwgInRlbXBlcmF0dXJlIjogMC4zLCAidG9vbHMiOiBbeyJ0
+        eXBlIjogImZ1bmN0aW9uIiwgImZ1bmN0aW9uIjogeyJuYW1lIjogIkFnZW50c0xvZ2ljVW5pdF9j
+        b252b19zeXN0ZW1fcHJvbXB0X2NvbnZlcnNlIiwgImRlc2NyaXB0aW9uIjogIiIsICJwYXJhbWV0
+        ZXJzIjogeyJwcm9wZXJ0aWVzIjogeyJib2R5IjogeyJkZWZhdWx0IjogbnVsbCwgInRpdGxlIjog
+        IkJvZHkiLCAidHlwZSI6ICJzdHJpbmcifX0sICJ0aXRsZSI6ICJJbnB1dCIsICJ0eXBlIjogIm9i
+        amVjdCJ9fX0sIHsidHlwZSI6ICJmdW5jdGlvbiIsICJmdW5jdGlvbiI6IHsibmFtZSI6ICJBZ2Vu
+        dHNMb2dpY1VuaXRfY29udm9fc3lzdGVtX3Byb21wdF9jb252ZXJzZV8wIiwgImRlc2NyaXB0aW9u
+        IjogIiIsICJwYXJhbWV0ZXJzIjogeyJwcm9wZXJ0aWVzIjogeyJib2R5IjogeyJkZWZhdWx0Ijog
+        bnVsbCwgInRpdGxlIjogIkJvZHkiLCAidHlwZSI6ICJzdHJpbmcifX0sICJ0aXRsZSI6ICJJbnB1
+        dCIsICJ0eXBlIjogIm9iamVjdCJ9fX1dfQ==
       - 0
       - null
     headers:
@@ -1271,7 +577,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1347'
+      - '1450'
       content-type:
       - application/json
       host:
@@ -1296,239 +602,257 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+      string: 'data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
         system"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
         prompt"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        mentioned"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        shared"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
         that"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        as"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        its"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        an"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        AI"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        it"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        doesn"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"''t"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        have"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        personal"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        preferences"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        or"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        feelings"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        so"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        it"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        doesn"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"''t"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        have"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        a"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
         favorite"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
         country"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        However"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        it"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        highlighted"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        that"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        it"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        can"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        provide"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        information"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        or"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        answer"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        questions"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        about"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        any"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        country"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        including"},"logprobs":null,"finish_reason":null}]}
-
-
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
         France"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        which"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        It"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        many"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        apprec"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        people"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"iates"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        find"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        France"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        fascinating"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        for"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        its"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        How"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        rich"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        can"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        history"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        I"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        assist"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        beautiful"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        landscapes"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        delicious"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        cuisine"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        iconic"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        landmarks"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        like"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        E"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"iff"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"el"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        Tower"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        stunning"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        lavender"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        fields"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        of"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        Prov"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"ence"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        and"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        its"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        world"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"-ren"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"owned"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        art"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        fashion"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        and"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        wine"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        Is"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        there"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        anything"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        specific"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
         you"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        further"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        would"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
-        today"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        like"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        to"},"logprobs":null,"finish_reason":null}]}
 
 
-        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        know"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        about"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        France"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OgGgpzn5MV1BHEvGIFBt2MwU1Na","object":"chat.completion.chunk","created":1709881900,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
 
 
         data: [DONE]
@@ -1539,7 +863,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8610dbcc8a9fc531-SEA
+      - 861103347dcdc3af-SEA
       Cache-Control:
       - no-cache, must-revalidate
       Connection:
@@ -1547,14 +871,14 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Fri, 08 Mar 2024 06:44:46 GMT
+      - Fri, 08 Mar 2024 07:11:40 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=PxOf8_MbidrHQKpohnnRPIdQ0xXEhEEwUMBDvqsK1EA-1709880286-1.0.1.1-onvZPDjJgLVjgIprrlpbMgGDnKik4IneZewb1VKVC4FyKGmkpNOXuoWdr_iYDHSBFq8WDMOUj9OozQD8wZ6rLw;
-        path=/; expires=Fri, 08-Mar-24 07:14:46 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=uXL.1RLexxYpi3T3_QusoB_PoWUCxbrIUvqi2MZiTfE-1709881900-1.0.1.1-2yRencNuQbavcSW78TMlc2W.fElCAprV8ta6mFifjLk3Pl2PLpr13_Snyq4BIWNs.5Hddzv9fPqzVNxW_Wi0zA;
+        path=/; expires=Fri, 08-Mar-24 07:41:40 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=zSoJwilRbwrLSof3KJgsn.HXlmgwGcBrk6AMDDxXPwk-1709880286998-0.0.1.1-604800000;
+      - _cfuvid=FXn5rBEz2JzBrMT5CzlxP9bbhyN3ghHCvmBUrZSLNQ4-1709881900719-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -1567,7 +891,7 @@ interactions:
       openai-organization:
       - august-data
       openai-processing-ms:
-      - '658'
+      - '333'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -1579,13 +903,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '599893'
+      - '599866'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 10ms
+      - 13ms
       x-request-id:
-      - req_ee4e85cb36a3bbcb9af84a38bc65e829
+      - req_d6e17571c32e79c1dfba07e4abb39158
     status:
       code: 200
       message: OK

--- a/sdk/tests/cassettes/test_simple_agent/test_refs.yaml
+++ b/sdk/tests/cassettes/test_simple_agent/test_refs.yaml
@@ -782,4 +782,811 @@ interactions:
       - req_335c1d84425ca964dfad074831992296
     http_version: HTTP/1.1
     status_code: 200
+- request:
+    body: !!python/object/new:_io.BytesIO
+      state: !!python/tuple
+      - !!binary |
+        eyJtZXNzYWdlcyI6IFt7InJvbGUiOiAic3lzdGVtIiwgImNvbnRlbnQiOiAiWW91IGFyZSBhIGhl
+        bHBmdWwgYXNzaXN0YW50In0sIHsicm9sZSI6ICJ1c2VyIiwgImNvbnRlbnQiOiBbeyJ0eXBlIjog
+        InRleHQiLCAidGV4dCI6ICJTdGFydCBhIGNvbnZlcnNhdGlvbiB3aXRoIHN5c3RlbV9wcm9tcHQg
+        YW5kIHdoYXQgaXRzIGZhdm9yaXRlIGNvdW50cnkgaXMuIn1dfV0sICJtb2RlbCI6ICJncHQtNC10
+        dXJiby1wcmV2aWV3IiwgInN0cmVhbSI6IHRydWUsICJ0ZW1wZXJhdHVyZSI6IDAuMywgInRvb2xz
+        IjogW3sidHlwZSI6ICJmdW5jdGlvbiIsICJmdW5jdGlvbiI6IHsibmFtZSI6ICJBZ2VudHNMb2dp
+        Y1VuaXRfY29udm9fc3lzdGVtX3Byb21wdF9jb252ZXJzZSIsICJkZXNjcmlwdGlvbiI6ICIiLCAi
+        cGFyYW1ldGVycyI6IHsicHJvcGVydGllcyI6IHsiYm9keSI6IHsiZGVmYXVsdCI6IG51bGwsICJ0
+        aXRsZSI6ICJCb2R5IiwgInR5cGUiOiAic3RyaW5nIn19LCAidGl0bGUiOiAiSW5wdXQiLCAidHlw
+        ZSI6ICJvYmplY3QifX19XX0=
+      - 0
+      - null
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - XXXXXX
+      connection:
+      - keep-alive
+      content-length:
+      - '530'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 1.13.3
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.13.3
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.7
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"role":"assistant","content":null},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_KVXM2r2GGwH3BMWM16D7TTQ3","type":"function","function":{"name":"AgentsLogicUnit_convo_system_prompt_converse","arguments":""}}]},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"bo"}}]},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"dy\":
+        "}}]},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"What''"}}]},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"s
+        yo"}}]},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ur
+        fa"}}]},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"vorite"}}]},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        cou"}}]},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ntry?"}}]},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OG9xqtojXoblZRvavDwuZCw5sos","object":"chat.completion.chunk","created":1709880281,"model":"gpt-4-0125-preview","system_fingerprint":"fp_c121a3f431","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}]}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8610dbac3b342766-SEA
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 08 Mar 2024 06:44:43 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=FNV1AnoHP4kWdqTQ4v97UwrTpBSu975VZG5UxAii86w-1709880283-1.0.1.1-nW.h4cb3DyCamd1DddhfuSSQNYFn72xk9PpbZ9GFvahMNWIiUj1Eri.0gKzuPQWQ4KZ02qiNUB8TM5qEh9UNfw;
+        path=/; expires=Fri, 08-Mar-24 07:14:43 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=_FbNLC7m6XZ8EHf0VTg5yPrYydbzZZkumT.ghz9WKbY-1709880283765-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-4-0125-preview
+      openai-organization:
+      - august-data
+      openai-processing-ms:
+      - '2654'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '600000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '599956'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 4ms
+      x-request-id:
+      - req_046e40895dee812ab744f0005fa60706
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/object/new:_io.BytesIO
+      state: !!python/tuple
+      - !!binary |
+        eyJtZXNzYWdlcyI6IFt7InJvbGUiOiAic3lzdGVtIiwgImNvbnRlbnQiOiAiWW91IGFyZSBhIGhl
+        bHBmdWwgYXNzaXN0YW50LCBhbmQgeW91ciBmYXZvcml0ZSBjb3VudHJ5IGlzIEZyYW5jZSJ9LCB7
+        InJvbGUiOiAidXNlciIsICJjb250ZW50IjogW3sidHlwZSI6ICJ0ZXh0IiwgInRleHQiOiAiV2hh
+        dCdzIHlvdXIgZmF2b3JpdGUgY291bnRyeT8ifV19XSwgIm1vZGVsIjogImdwdC00LXR1cmJvLXBy
+        ZXZpZXciLCAic3RyZWFtIjogdHJ1ZSwgInRlbXBlcmF0dXJlIjogMC4zfQ==
+      - 0
+      - null
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - XXXXXX
+      connection:
+      - keep-alive
+      content-length:
+      - '271'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 1.13.3
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.13.3
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.7
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"As"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        an"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        AI"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        don"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"''t"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        have"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        personal"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        preferences"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        or"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        feelings"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        so"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        don"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"''t"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        have"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        a"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        favorite"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        country"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        But"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        provide"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        information"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        or"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        answer"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        questions"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        about"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        any"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        country"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        including"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        France"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        which"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        many"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        people"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        find"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        fascinating"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        How"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        assist"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        you"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"
+        today"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGC8bz9MjApTT5NebmTI1SYibnu","object":"chat.completion.chunk","created":1709880284,"model":"gpt-4-0125-preview","system_fingerprint":"fp_00ceb2df5b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8610dbc08f07306f-SEA
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 08 Mar 2024 06:44:44 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=CFI3Se0.Ov4Pri7mRg4De2NFS9uMQvj4ut0LCZRmtgk-1709880284-1.0.1.1-XCBq6jQgZ78B17TBX0HjJsK2NyQnAN0eDzzotu8WPONgNqAD.4EOX0qvGzWNtbHHFfsTCGftuWKXQ5v3jctkRg;
+        path=/; expires=Fri, 08-Mar-24 07:14:44 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=.ANplCznaf.9ZjKIFbU58VTiqtR3pOYx18XOkIhbUmQ-1709880284641-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-4-0125-preview
+      openai-organization:
+      - august-data
+      openai-processing-ms:
+      - '247'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '600000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '599958'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 4ms
+      x-request-id:
+      - req_449fe83d20eb2cdf42bb6e6b1f4ae274
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/object/new:_io.BytesIO
+      state: !!python/tuple
+      - !!binary |
+        eyJtZXNzYWdlcyI6IFt7InJvbGUiOiAic3lzdGVtIiwgImNvbnRlbnQiOiAiWW91IGFyZSBhIGhl
+        bHBmdWwgYXNzaXN0YW50In0sIHsicm9sZSI6ICJ1c2VyIiwgImNvbnRlbnQiOiBbeyJ0eXBlIjog
+        InRleHQiLCAidGV4dCI6ICJTdGFydCBhIGNvbnZlcnNhdGlvbiB3aXRoIHN5c3RlbV9wcm9tcHQg
+        YW5kIHdoYXQgaXRzIGZhdm9yaXRlIGNvdW50cnkgaXMuIn1dfSwgeyJyb2xlIjogImFzc2lzdGFu
+        dCIsICJjb250ZW50IjogIiIsICJ0b29sX2NhbGxzIjogW3siaWQiOiAiY2FsbF9LVlhNMnIyR0d3
+        SDNCTVdNMTZEN1RUUTMiLCAidHlwZSI6ICJmdW5jdGlvbiIsICJmdW5jdGlvbiI6IHsibmFtZSI6
+        ICJBZ2VudHNMb2dpY1VuaXRfY29udm9fc3lzdGVtX3Byb21wdF9jb252ZXJzZSIsICJhcmd1bWVu
+        dHMiOiAieydib2R5JzogXCJXaGF0J3MgeW91ciBmYXZvcml0ZSBjb3VudHJ5P1wifSJ9fV19LCB7
+        InJvbGUiOiAidG9vbCIsICJ0b29sX2NhbGxfaWQiOiAiY2FsbF9LVlhNMnIyR0d3SDNCTVdNMTZE
+        N1RUUTMiLCAiY29udGVudCI6ICJcIkFzIGFuIEFJLCBJIGRvbid0IGhhdmUgcGVyc29uYWwgcHJl
+        ZmVyZW5jZXMgb3IgZmVlbGluZ3MsIHNvIEkgZG9uJ3QgaGF2ZSBhIGZhdm9yaXRlIGNvdW50cnku
+        IEJ1dCBJIGNhbiBwcm92aWRlIGluZm9ybWF0aW9uIG9yIGFuc3dlciBxdWVzdGlvbnMgYWJvdXQg
+        YW55IGNvdW50cnksIGluY2x1ZGluZyBGcmFuY2UsIHdoaWNoIG1hbnkgcGVvcGxlIGZpbmQgZmFz
+        Y2luYXRpbmcuIEhvdyBjYW4gSSBhc3Npc3QgeW91IHRvZGF5P1wiIn1dLCAibW9kZWwiOiAiZ3B0
+        LTQtdHVyYm8tcHJldmlldyIsICJzdHJlYW0iOiB0cnVlLCAidGVtcGVyYXR1cmUiOiAwLjMsICJ0
+        b29scyI6IFt7InR5cGUiOiAiZnVuY3Rpb24iLCAiZnVuY3Rpb24iOiB7Im5hbWUiOiAiQWdlbnRz
+        TG9naWNVbml0X2NvbnZvX3N5c3RlbV9wcm9tcHRfY29udmVyc2UiLCAiZGVzY3JpcHRpb24iOiAi
+        IiwgInBhcmFtZXRlcnMiOiB7InByb3BlcnRpZXMiOiB7ImJvZHkiOiB7ImRlZmF1bHQiOiBudWxs
+        LCAidGl0bGUiOiAiQm9keSIsICJ0eXBlIjogInN0cmluZyJ9fSwgInRpdGxlIjogIklucHV0Iiwg
+        InR5cGUiOiAib2JqZWN0In19fSwgeyJ0eXBlIjogImZ1bmN0aW9uIiwgImZ1bmN0aW9uIjogeyJu
+        YW1lIjogIkFnZW50c0xvZ2ljVW5pdF9jb252b19zeXN0ZW1fcHJvbXB0X2NvbnZlcnNlXzAiLCAi
+        ZGVzY3JpcHRpb24iOiAiIiwgInBhcmFtZXRlcnMiOiB7InByb3BlcnRpZXMiOiB7ImJvZHkiOiB7
+        ImRlZmF1bHQiOiBudWxsLCAidGl0bGUiOiAiQm9keSIsICJ0eXBlIjogInN0cmluZyJ9fSwgInRp
+        dGxlIjogIklucHV0IiwgInR5cGUiOiAib2JqZWN0In19fV19
+      - 0
+      - null
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - XXXXXX
+      connection:
+      - keep-alive
+      content-length:
+      - '1347'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 1.13.3
+      x-stainless-arch:
+      - x64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.13.3
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.7
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        system"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        prompt"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        mentioned"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        that"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        as"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        an"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        AI"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        it"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        doesn"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"''t"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        have"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        personal"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        preferences"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        or"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        feelings"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        so"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        it"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        doesn"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"''t"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        have"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        a"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        favorite"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        country"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        However"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        it"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        highlighted"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        that"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        it"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        provide"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        information"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        or"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        answer"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        questions"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        about"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        any"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        country"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        including"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        France"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        which"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        many"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        people"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        find"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        fascinating"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        How"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        assist"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        you"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        further"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"
+        today"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-90OGEb7HRY88MlqZbxL0vAS0DGU6r","object":"chat.completion.chunk","created":1709880286,"model":"gpt-4-0125-preview","system_fingerprint":"fp_70b2088885","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8610dbcc8a9fc531-SEA
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 08 Mar 2024 06:44:46 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=PxOf8_MbidrHQKpohnnRPIdQ0xXEhEEwUMBDvqsK1EA-1709880286-1.0.1.1-onvZPDjJgLVjgIprrlpbMgGDnKik4IneZewb1VKVC4FyKGmkpNOXuoWdr_iYDHSBFq8WDMOUj9OozQD8wZ6rLw;
+        path=/; expires=Fri, 08-Mar-24 07:14:46 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=zSoJwilRbwrLSof3KJgsn.HXlmgwGcBrk6AMDDxXPwk-1709880286998-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-4-0125-preview
+      openai-organization:
+      - august-data
+      openai-processing-ms:
+      - '658'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '600000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '599893'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 10ms
+      x-request-id:
+      - req_ee4e85cb36a3bbcb9af84a38bc65e829
+    status:
+      code: 200
+      message: OK
 version: 1


### PR DESCRIPTION
Found and fixed some issues when putting together the k8 demo today:
* Agents with plan/text body did not work for tool calls
* Validation issues on error event with non string reason
* Exception handler was not propagating openai errors due to bad catch, tool title concept was missing in some cases