### PR TITLE
Fix missing @docsearch/css dependency in main

### DIFF
--- a/webui/apps/docs/package.json
+++ b/webui/apps/docs/package.json
@@ -17,6 +17,7 @@
     "@astrojs/starlight": "^0.25.2",
     "@astrolib/analytics": "^0.5.0",
     "@astrolib/seo": "1.0.0-beta.5",
+    "@docsearch/css": "^3.6.1",
     "@docsearch/js": "^3.6.1",
     "@expressive-code/plugin-collapsible-sections": "^0.35.3",
     "@fontsource-variable/inter": "^5.0.19",

--- a/webui/pnpm-lock.yaml
+++ b/webui/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@astrolib/seo':
         specifier: 1.0.0-beta.5
         version: 1.0.0-beta.5(astro@4.12.2(@types/node@20.14.12)(lightningcss@1.24.1)(terser@5.30.0)(typescript@5.5.4))
+      '@docsearch/css':
+        specifier: ^3.6.1
+        version: 3.6.1
       '@docsearch/js':
         specifier: ^3.6.1
         version: 3.6.1(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)


### PR DESCRIPTION
@docsearch/css  is missing from the docs and it's breaking main

see workflow:
https://github.com/eidolon-ai/eidolon/actions/runs/10071838847/job/27842650218?pr=573