### PR TITLE
no margin top for code terminal things

### DIFF
--- a/webui/apps/docs/src/assets/styles/tailwind.css
+++ b/webui/apps/docs/src/assets/styles/tailwind.css
@@ -88,3 +88,7 @@
 .dd *:first-child {
   margin-top: 0;
 }
+
+.frame.is-terminal figcaption + pre {
+  margin-top: 0;
+}


### PR DESCRIPTION
Problem
<img width="733" alt="Screenshot 2024-07-25 at 5 54 05 PM" src="https://github.com/user-attachments/assets/d56be0b0-4689-4c3e-a642-3837d411e291">
Fixed
<img width="759" alt="Screenshot 2024-07-25 at 5 53 55 PM" src="https://github.com/user-attachments/assets/7eff7352-e0fd-490b-998a-451f441a92a1">