### PR TITLE
Quickstart docs improvement: OPENAI_API_KEY context

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ cd eidolon-quickstart
 make docker-serve
 ```
 
+This command will download the dependencies required to run your agent machine and start the Eidolon http server in
+"dev-mode".
+
+---
+
+The first time you run this command, you may be prompted to enter credentials that the machine needs
+to run (ie, [OpenAI API Key](https://platform.openai.com/api-keys)):
+
+```
+💭 OPENAI_API_KEY (required):
+```
+
+Please note that your OPEN_API_KEY must belong to an account with [at least a $5 balance](https://platform.openai.com/docs/guides/rate-limits/tier-1-rate-limits), or you won't be able to run the [GPT-4 Turbo model](https://help.openai.com/en/articles/8555510-gpt-4-turbo-in-the-openai-api) required to run the server.
+
+You'll know this is an issue if you see this output:
+
+```
+raise self._make_status_error_from_response(err.response) from None
+openai.NotFoundError: Error code: 404 - {'error': {'message': 'The model `gpt-4-turbo` does not exist or you do not have access to it.', 'type': 'invalid_request_error', 'param': None, 'code': 'model_not_found'}}
+```
+
+---
+
 If your AgentMachine successfully started, you should see the following logs in your terminal.
 ```bash
 INFO - Building machine 'local_dev'

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ to run (ie, [OpenAI API Key](https://platform.openai.com/api-keys)):
 💭 OPENAI_API_KEY (required):
 ```
 
-Please note that your OPEN_API_KEY must belong to an account with [at least a $5 balance](https://platform.openai.com/docs/guides/rate-limits/tier-1-rate-limits), or you won't be able to run the [GPT-4 Turbo model](https://help.openai.com/en/articles/8555510-gpt-4-turbo-in-the-openai-api) required to run the server.
+Please note that your `OPENAI_API_KEY` must belong to an account with [at least a $5 balance](https://platform.openai.com/docs/guides/rate-limits/tier-1-rate-limits), or you won't be able to run the [GPT-4 Turbo model](https://help.openai.com/en/articles/8555510-gpt-4-turbo-in-the-openai-api) required to run the server.
 
 You'll know this is an issue if you see this output:
 


### PR DESCRIPTION
## Summary

When getting my project running locally, I had some confusion around the `OPENAI_API_KEY` requirement.

This addition to the docs should help new contributors in the AI space avoid this little "speedbump".

## Preview

<img width="1043" alt="Screenshot 2024-08-21 at 3 29 26 AM" src="https://github.com/user-attachments/assets/0b787afe-496c-4eed-88cf-5c2e35af2799">

