### PR TITLE
docs unordered lists #696

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -36,7 +36,7 @@ You will also need a running Eidolon Machine. For instructions on how to run a m
 ### Setting Up Your Environment
 
 **Environment Configuration**:
-You need to create a `.env` file in the **webui/app/eidolon-ui2** directory of the project. Copy
+You need to create a `.env` file in the **webui/apps/eidolon-ui2** directory of the project. Copy
 the contents of the 'template.env' file and paste it into the `.env` file.
 
 The content are described in the template file.

--- a/webui/apps/docs/src/assets/styles/tailwind.css
+++ b/webui/apps/docs/src/assets/styles/tailwind.css
@@ -2,6 +2,27 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  .markdown ul {
+    min-width: 0;
+    padding-left: 2rem;
+    list-style-type: disc;
+    margin-top: -.25rem;
+  }
+
+  .markdown ol {
+    min-width: 0;
+    padding-left: 2rem;
+    list-style-type: decimal;
+    margin-top: -.25rem;
+  }
+
+  .markdown ol > li {
+    overflow-wrap: break-word;
+    white-space: normal;
+  }
+}
+
 @layer utilities {
   .bg-page {
     background-color: var(--aw-color-bg-page);

--- a/webui/apps/docs/src/assets/styles/tailwind.css
+++ b/webui/apps/docs/src/assets/styles/tailwind.css
@@ -3,21 +3,21 @@
 @tailwind utilities;
 
 @layer base {
-  ul {
+  .sl-markdown-content ul {
     min-width: 0;
     padding-left: 2rem;
     list-style-type: disc;
     margin-top: -.25rem;
   }
 
-  ol {
+  .sl-markdown-content ol {
     min-width: 0;
     padding-left: 2rem;
     list-style-type: decimal;
     margin-top: -.25rem;
   }
 
-  ol > li {
+  .sl-markdown-content ol > li {
     overflow-wrap: break-word;
     white-space: normal;
   }

--- a/webui/apps/docs/src/assets/styles/tailwind.css
+++ b/webui/apps/docs/src/assets/styles/tailwind.css
@@ -3,21 +3,21 @@
 @tailwind utilities;
 
 @layer base {
-  .markdown ul {
+  ul {
     min-width: 0;
     padding-left: 2rem;
     list-style-type: disc;
     margin-top: -.25rem;
   }
 
-  .markdown ol {
+  ol {
     min-width: 0;
     padding-left: 2rem;
     list-style-type: decimal;
     margin-top: -.25rem;
   }
 
-  .markdown ol > li {
+  ol > li {
     overflow-wrap: break-word;
     white-space: normal;
   }


### PR DESCRIPTION
During standup I noticed another page where bullets don't show up. Followed instructions starting at https://tailwindcss.com/docs/preflight#lists-are-unstyled.

Copied formatting for unordered and ordered lists from our repo:

https://github.com/eidolon-ai/eidolon/blob/2f52e2f6ce135ebed82eaee40f59d974ab6e9d20/webui/packages/eidolon-components/src/client/messages/eidolon-markdown.module.css#L69
